### PR TITLE
Add posts and connection features

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -766,6 +766,74 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(500).json({ message: "Failed to get template" });
     }
   });
+
+  // Post APIs
+  app.get("/api/posts", async (req, res) => {
+    const userId = req.session.userId || 1;
+    const posts = await storage.getPostsByUserId(userId);
+    res.status(200).json(posts);
+  });
+
+  app.get("/api/users/:userId/posts", async (req, res) => {
+    const userId = parseInt(req.params.userId);
+    const posts = await storage.getPostsByUserId(userId);
+    res.status(200).json(posts);
+  });
+
+  app.post("/api/posts", async (req, res) => {
+    const userId = req.session.userId || 1;
+    const { content } = req.body;
+    if (!content) {
+      return res.status(400).json({ message: "Content is required" });
+    }
+    const post = await storage.createPost({ userId, content });
+    res.status(201).json(post);
+  });
+
+  app.put("/api/posts/:id", async (req, res) => {
+    const postId = parseInt(req.params.id);
+    const post = await storage.getPost(postId);
+    if (!post) {
+      return res.status(404).json({ message: "Post not found" });
+    }
+    const updated = await storage.updatePost(postId, { content: req.body.content });
+    res.status(200).json(updated);
+  });
+
+  app.delete("/api/posts/:id", async (req, res) => {
+    const postId = parseInt(req.params.id);
+    const ok = await storage.deletePost(postId);
+    if (!ok) {
+      return res.status(404).json({ message: "Post not found" });
+    }
+    res.status(200).json({ message: "Post deleted" });
+  });
+
+  // Connection APIs
+  app.get("/api/connections", async (req, res) => {
+    const userId = req.session.userId || 1;
+    const conns = await storage.getConnectionsByUserId(userId);
+    res.status(200).json(conns);
+  });
+
+  app.post("/api/connections", async (req, res) => {
+    const userId = req.session.userId || 1;
+    const { connectedUserId } = req.body;
+    if (!connectedUserId) {
+      return res.status(400).json({ message: "connectedUserId is required" });
+    }
+    const conn = await storage.createConnection({ userId, connectedUserId });
+    res.status(201).json(conn);
+  });
+
+  app.delete("/api/connections/:id", async (req, res) => {
+    const id = parseInt(req.params.id);
+    const ok = await storage.deleteConnection(id);
+    if (!ok) {
+      return res.status(404).json({ message: "Connection not found" });
+    }
+    res.status(200).json({ message: "Connection deleted" });
+  });
   
   // Project Export API
   app.get("/api/projects/:id/export", async (req, res) => {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,16 +1,22 @@
-import { 
-  users, 
-  projects, 
-  files, 
-  templates, 
-  type User, 
-  type InsertUser, 
-  type Project, 
-  type InsertProject, 
-  type File, 
-  type InsertFile, 
-  type Template, 
-  type InsertTemplate 
+import {
+  users,
+  projects,
+  files,
+  templates,
+  posts,
+  connections,
+  type User,
+  type InsertUser,
+  type Project,
+  type InsertProject,
+  type File,
+  type InsertFile,
+  type Template,
+  type InsertTemplate,
+  type Post,
+  type InsertPost,
+  type Connection,
+  type InsertConnection
 } from "@shared/schema";
 
 export interface IStorage {
@@ -34,6 +40,19 @@ export interface IStorage {
   createFile(file: InsertFile): Promise<File>;
   updateFile(id: number, fileData: Partial<InsertFile>): Promise<File | undefined>;
   deleteFile(id: number): Promise<boolean>;
+
+  // Post operations
+  getPost(id: number): Promise<Post | undefined>;
+  getPostsByUserId(userId: number): Promise<Post[]>;
+  createPost(post: InsertPost): Promise<Post>;
+  updatePost(id: number, postData: Partial<InsertPost>): Promise<Post | undefined>;
+  deletePost(id: number): Promise<boolean>;
+
+  // Connection operations
+  getConnection(id: number): Promise<Connection | undefined>;
+  getConnectionsByUserId(userId: number): Promise<Connection[]>;
+  createConnection(connection: InsertConnection): Promise<Connection>;
+  deleteConnection(id: number): Promise<boolean>;
   
   // Template operations
   getTemplate(id: number): Promise<Template | undefined>;
@@ -47,22 +66,30 @@ export class MemStorage implements IStorage {
   private projects: Map<number, Project>;
   private files: Map<number, File>;
   private templates: Map<number, Template>;
+  private posts: Map<number, Post>;
+  private connections: Map<number, Connection>;
   
   private userId: number;
   private projectId: number;
   private fileId: number;
   private templateId: number;
+  private postId: number;
+  private connectionId: number;
 
   constructor() {
     this.users = new Map();
     this.projects = new Map();
     this.files = new Map();
     this.templates = new Map();
+    this.posts = new Map();
+    this.connections = new Map();
     
     this.userId = 1;
     this.projectId = 1;
     this.fileId = 1;
     this.templateId = 1;
+    this.postId = 1;
+    this.connectionId = 1;
     
     // Initialize with sample templates
     this.initializeTemplates();
@@ -256,6 +283,60 @@ export class MemStorage implements IStorage {
     
     this.templates.set(id, template);
     return template;
+  }
+
+  // Post operations
+  async getPost(id: number): Promise<Post | undefined> {
+    return this.posts.get(id);
+  }
+
+  async getPostsByUserId(userId: number): Promise<Post[]> {
+    return Array.from(this.posts.values()).filter(p => p.userId === userId);
+  }
+
+  async createPost(insertPost: InsertPost): Promise<Post> {
+    const id = this.postId++;
+    const now = new Date();
+    const post: Post = { ...insertPost, id, createdAt: now, updatedAt: now };
+    this.posts.set(id, post);
+    return post;
+  }
+
+  async updatePost(id: number, postData: Partial<InsertPost>): Promise<Post | undefined> {
+    const post = this.posts.get(id);
+    if (!post) return undefined;
+
+    const now = new Date();
+    const updatedPost: Post = { ...post, ...postData, updatedAt: now };
+    this.posts.set(id, updatedPost);
+    return updatedPost;
+  }
+
+  async deletePost(id: number): Promise<boolean> {
+    return this.posts.delete(id);
+  }
+
+  // Connection operations
+  async getConnection(id: number): Promise<Connection | undefined> {
+    return this.connections.get(id);
+  }
+
+  async getConnectionsByUserId(userId: number): Promise<Connection[]> {
+    return Array.from(this.connections.values()).filter(
+      c => c.userId === userId
+    );
+  }
+
+  async createConnection(insertConn: InsertConnection): Promise<Connection> {
+    const id = this.connectionId++;
+    const now = new Date();
+    const connection: Connection = { ...insertConn, id, createdAt: now };
+    this.connections.set(id, connection);
+    return connection;
+  }
+
+  async deleteConnection(id: number): Promise<boolean> {
+    return this.connections.delete(id);
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -44,10 +44,36 @@ export const templates = pgTable("templates", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
+export const posts = pgTable("posts", {
+  id: serial("id").primaryKey(),
+  userId: integer("user_id").notNull().references(() => users.id),
+  content: text("content").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const connections = pgTable("connections", {
+  id: serial("id").primaryKey(),
+  userId: integer("user_id").notNull().references(() => users.id),
+  connectedUserId: integer("connected_user_id")
+    .notNull()
+    .references(() => users.id),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
 export const insertUserSchema = createInsertSchema(users).omit({ id: true, createdAt: true });
 export const insertProjectSchema = createInsertSchema(projects).omit({ id: true, createdAt: true, updatedAt: true });
 export const insertFileSchema = createInsertSchema(files).omit({ id: true, createdAt: true, updatedAt: true });
 export const insertTemplateSchema = createInsertSchema(templates).omit({ id: true, createdAt: true });
+export const insertPostSchema = createInsertSchema(posts).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+export const insertConnectionSchema = createInsertSchema(connections).omit({
+  id: true,
+  createdAt: true,
+});
 
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type User = typeof users.$inferSelect;
@@ -60,3 +86,9 @@ export type File = typeof files.$inferSelect;
 
 export type InsertTemplate = z.infer<typeof insertTemplateSchema>;
 export type Template = typeof templates.$inferSelect;
+
+export type InsertPost = z.infer<typeof insertPostSchema>;
+export type Post = typeof posts.$inferSelect;
+
+export type InsertConnection = z.infer<typeof insertConnectionSchema>;
+export type Connection = typeof connections.$inferSelect;


### PR DESCRIPTION
## Summary
- extend schema with `posts` and `connections` tables
- implement post/connection methods in the memory storage layer
- add API endpoints for posts and connections

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6872acc7fa20832a9a517bba6d22bbd1