### PR TITLE
Add AI code analysis functionality

### DIFF
--- a/client/src/components/ai/chat-interface.tsx
+++ b/client/src/components/ai/chat-interface.tsx
@@ -12,15 +12,16 @@ interface ChatInterfaceProps {
 
 const ChatInterface: React.FC<ChatInterfaceProps> = ({ className = '' }) => {
   const { t } = useI18n();
-  const { 
-    chatMessages, 
-    sendChatMessage, 
-    userPrompt, 
-    setUserPrompt, 
-    selectedModel, 
+  const {
+    chatMessages,
+    sendChatMessage,
+    userPrompt,
+    setUserPrompt,
+    selectedModel,
     setSelectedModel,
     isGenerating,
-    insertGeneratedCode
+    insertGeneratedCode,
+    analyzeActiveFile
   } = useEditor();
   
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -129,16 +130,24 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ className = '' }) => {
             <SelectTrigger className="text-xs bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md p-1 h-8 w-28">
               <SelectValue placeholder="Select model" />
             </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="openai">GPT-4</SelectItem>
-              <SelectItem value="anthropic">Claude</SelectItem>
-            </SelectContent>
-          </Select>
-          <Button 
-            variant="ghost" 
-            size="icon"
-            className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
-          >
+          <SelectContent>
+            <SelectItem value="openai">GPT-4</SelectItem>
+            <SelectItem value="anthropic">Claude</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={analyzeActiveFile}
+          className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+        >
+          <i className="ri-file-search-line"></i>
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+        >
             <i className="ri-settings-line"></i>
           </Button>
         </div>

--- a/client/src/contexts/editor-context.tsx
+++ b/client/src/contexts/editor-context.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState } from 'react';
 import { useToast } from '@/hooks/use-toast';
-import { generateCodeWithOpenAI } from '@/lib/openai';
-import { generateCodeWithAnthropic } from '@/lib/anthropic';
+import { generateCodeWithOpenAI, analyzeCodeWithOpenAI } from '@/lib/openai';
+import { generateCodeWithAnthropic, analyzeCodeWithAnthropic } from '@/lib/anthropic';
 import { ProjectFile } from '@/types';
 import { AIModel, ChatMessage, PreviewDevice } from '@/types';
 
@@ -20,6 +20,7 @@ interface EditorContextType {
   setUserPrompt: (prompt: string) => void;
   sendChatMessage: (message: string) => Promise<void>;
   insertGeneratedCode: (code: string) => void;
+  analyzeActiveFile: () => Promise<void>;
 }
 
 const EditorContext = createContext<EditorContextType>({
@@ -37,6 +38,7 @@ const EditorContext = createContext<EditorContextType>({
   setUserPrompt: () => {},
   sendChatMessage: async () => {},
   insertGeneratedCode: () => {},
+  analyzeActiveFile: async () => {},
 });
 
 export const useEditor = () => useContext(EditorContext);
@@ -134,6 +136,50 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     }
   };
 
+  const analyzeActiveFile = async (): Promise<void> => {
+    if (!activeFile) {
+      toast({
+        title: "Cannot analyze code",
+        description: "No file is currently active in the editor",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      setIsGenerating(true);
+
+      const analysis = selectedModel === 'openai'
+        ? await analyzeCodeWithOpenAI(activeFileContent)
+        : await analyzeCodeWithAnthropic(activeFileContent);
+
+      const userMessage: ChatMessage = {
+        id: Date.now().toString(),
+        role: 'user',
+        content: `Analyze file ${activeFile.name}`,
+        timestamp: new Date()
+      };
+
+      const aiMessage: ChatMessage = {
+        id: (Date.now() + 1).toString(),
+        role: 'assistant',
+        content: analysis,
+        timestamp: new Date()
+      };
+
+      setChatMessages(prev => [...prev, userMessage, aiMessage]);
+    } catch (err: any) {
+      const errorMsg = err.message || 'Failed to analyze code';
+      toast({
+        title: "Code analysis failed",
+        description: errorMsg,
+        variant: "destructive",
+      });
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
   const value = {
     activeFile,
     activeFileContent,
@@ -149,6 +195,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     setUserPrompt,
     sendChatMessage,
     insertGeneratedCode,
+    analyzeActiveFile,
   };
 
   return <EditorContext.Provider value={value}>{children}</EditorContext.Provider>;

--- a/client/src/lib/anthropic.ts
+++ b/client/src/lib/anthropic.ts
@@ -5,6 +5,10 @@ interface CodeGenerationResponse {
   code: string;
 }
 
+interface CodeAnalysisResponse {
+  analysis: string;
+}
+
 /**
  * Generates code using Anthropic's API
  * @param prompt The prompt to send to the API
@@ -32,17 +36,13 @@ export async function generateCodeWithAnthropic(prompt: string): Promise<string>
  */
 export async function analyzeCodeWithAnthropic(code: string): Promise<string> {
   try {
-    const prompt = `Analyze the following code and provide insights on improvements:
-    
-    ${code}`;
-    
-    const response = await apiRequest('POST', '/api/ai/generate', {
-      prompt,
+    const response = await apiRequest('POST', '/api/ai/analyze', {
+      code,
       model: 'anthropic'
     });
-    
-    const data: CodeGenerationResponse = await response.json();
-    return data.code;
+
+    const data: CodeAnalysisResponse = await response.json();
+    return data.analysis;
   } catch (error) {
     console.error("Anthropic code analysis error:", error);
     throw new Error(`Failed to analyze code with Anthropic: ${error}`);

--- a/client/src/lib/openai.ts
+++ b/client/src/lib/openai.ts
@@ -5,6 +5,10 @@ interface CodeGenerationResponse {
   code: string;
 }
 
+interface CodeAnalysisResponse {
+  analysis: string;
+}
+
 /**
  * Generates code using OpenAI's API
  * @param prompt The prompt to send to the API
@@ -32,17 +36,13 @@ export async function generateCodeWithOpenAI(prompt: string): Promise<string> {
  */
 export async function analyzeCodeWithOpenAI(code: string): Promise<string> {
   try {
-    const prompt = `Analyze the following code and provide insights on improvements:
-    
-    ${code}`;
-    
-    const response = await apiRequest('POST', '/api/ai/generate', {
-      prompt,
+    const response = await apiRequest('POST', '/api/ai/analyze', {
+      code,
       model: 'openai'
     });
-    
-    const data: CodeGenerationResponse = await response.json();
-    return data.code;
+
+    const data: CodeAnalysisResponse = await response.json();
+    return data.analysis;
   } catch (error) {
     console.error("OpenAI code analysis error:", error);
     throw new Error(`Failed to analyze code with OpenAI: ${error}`);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -569,6 +569,66 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(500).json({ message: "Failed to generate code" });
     }
   });
+
+  // API for analyzing code and providing improvement suggestions
+  app.post("/api/ai/analyze", async (req, res) => {
+    try {
+      const { code, model = "openai" } = req.body;
+
+      if (!code) {
+        return res.status(400).json({ message: "Code is required" });
+      }
+
+      let analysis;
+
+      if (model === "openai") {
+        // the newest OpenAI model is "gpt-4o" which was released May 13, 2024. do not change this unless explicitly requested by the user
+        const response = await openai.chat.completions.create({
+          model: "gpt-4o",
+          messages: [
+            {
+              role: "system",
+              content: "You are a senior developer. Provide suggestions to improve the following code."
+            },
+            {
+              role: "user",
+              content: code
+            }
+          ]
+        });
+
+        analysis = response.choices[0].message.content;
+      } else if (model === "anthropic") {
+        // the newest Anthropic model is "claude-3-7-sonnet-20250219" which was released February 24, 2025. Do not change this unless explicitly requested by the user.
+        const response = await anthropic.messages.create({
+          model: "claude-3-7-sonnet-20250219",
+          max_tokens: 4000,
+          system: "You are a senior developer. Provide suggestions to improve the following code.",
+          messages: [
+            {
+              role: "user",
+              content: code
+            }
+          ]
+        });
+
+        if (response.content && response.content.length > 0) {
+          const content = response.content;
+          // @ts-ignore - Ignoring type check for Anthropic API response
+          analysis = content[0].text || JSON.stringify(content);
+        } else {
+          analysis = "No content returned from AI";
+        }
+      } else {
+        return res.status(400).json({ message: "Invalid model specified" });
+      }
+
+      res.status(200).json({ analysis });
+    } catch (error) {
+      console.error("AI code analysis error:", error);
+      res.status(500).json({ message: "Failed to analyze code" });
+    }
+  });
   
   // API for generating complete applications based on a description
   app.post("/api/ai/generate-app", async (req, res) => {


### PR DESCRIPTION
## Summary
- extend OpenAI and Anthropic client libs with a new `/api/ai/analyze` endpoint
- implement `/api/ai/analyze` route on the server
- support analyzing the active file from the editor context
- expose analyze feature in chat interface via new button

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6872b475bb84832a95693a8b74d92c1d