### PR TITLE
Update homepage welcome title

### DIFF
--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -21,7 +21,7 @@ const translations: Translations = {
     settings: 'Settings',
     signOut: 'Sign Out',
     // Welcome Banner
-    welcomeTitle: 'Welcome to Xalgrow!',
+    welcomeTitle: 'OneBay',
     welcomeDescription: 'The AI-powered coding assistant that helps you build full-stack applications with ease. Generate, edit, and preview your code in real-time.',
     newProject: 'New Project',
     tutorials: 'Tutorials',
@@ -89,7 +89,7 @@ const translations: Translations = {
     settings: 'सेटिंग्स',
     signOut: 'साइन आउट',
     // Welcome Banner
-    welcomeTitle: 'Xalgrow में आपका स्वागत है!',
+    welcomeTitle: 'OneBay',
     welcomeDescription: 'AI-संचालित कोडिंग सहायक जो आपको फुल-स्टैक एप्लिकेशन बनाने में मदद करता है। रियल-टाइम में अपना कोड जनरेट करें, संपादित करें और प्रीव्यू करें।',
     newProject: 'नया प्रोजेक्ट',
     tutorials: 'ट्यूटोरियल',


### PR DESCRIPTION
## Summary
- modify the English and Hindi translations so the welcome banner displays **OneBay** instead of **Welcome to Xalgrow**

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6872b8c6eff8832aa4748eff39076d9e