### PR TITLE
Add demo button to dashboard

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -63,19 +63,27 @@ const Dashboard: React.FC = () => {
           <h1 className="text-3xl font-bold">{t('dashboard.myProjects')}</h1>
           
           <div className="space-x-2">
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               onClick={() => setShowGenerateAppDialog(true)}
               className="flex items-center"
             >
               <Sparkles className="mr-2 h-4 w-4" /> {t('dashboard.generateApp')}
             </Button>
-            
-            <Button 
+
+            <Button
               onClick={() => setShowNewProjectDialog(true)}
               className="flex items-center"
             >
               <Plus className="mr-2 h-4 w-4" /> {t('dashboard.newProject')}
+            </Button>
+
+            {/* Temporary demo button */}
+            <Button
+              variant="secondary"
+              onClick={() => alert('Hello from Xalgrow!')}
+            >
+              Say Hello
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a small demo button to the dashboard page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6872c47fbd74832a976e24e8764b5a44